### PR TITLE
Ending game

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -4,6 +4,10 @@ body {
   background: black !important;
 }
 
+hr {
+  background-color: #b8b8b8;
+}
+
 $booyah-box-box-shadow: 1px 1px 2px 0 #d0d0d0;
 $booyah-box-link-color: #289bff;
 

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,10 @@
 // Place all the styles related to the users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.game-history-entry {
+	
+	.entry-header {
+
+	}
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -3,8 +3,24 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .game-history-entry {
-	
-	.entry-header {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr 1fr;
 
+	&.entry-header {
+		color: black;
+		background-color: white;
+		font-weight: bold;
+		border-radius: 5rem;
+		margin-left: -0.5rem;
+		margin-right: -0.5rem;
+		margin-bottom: 1rem;
 	}
+}
+
+.win-loss-draw-stats {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	font-size: 1.75rem;
+	font-weight: bold;
+	padding-top: 0.25rem;
 }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -2,7 +2,7 @@ load 'lib/assets/view_bro.rb'
 
 class GamesController < ApplicationController
 
-  before_action :authenticate_user!, only: [:index, :new, :create, :show, :update, :join_as_black, :join_as_white, :game_available, :forfeit]
+  before_action :authenticate_user!
 
   def index
     @games = Game.all
@@ -70,6 +70,7 @@ class GamesController < ApplicationController
   def join_as_black
     @game = Game.find(params[:id])
     return render_not_found if @game.nil?
+    @game.transmit_player_on_move_to_firebase(1)
     @game.update_attribute(:black_player_id, current_user.id)
     redirect_to game_path(@game.id)
   end
@@ -77,6 +78,7 @@ class GamesController < ApplicationController
   def join_as_white
     @game = Game.find(params[:id])
     return render_not_found if @game.nil?
+    @game.transmit_player_on_move_to_firebase(1)
     @game.update_attribute(:white_player_id, current_user.id)
     redirect_to game_path(@game.id)
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -98,7 +98,7 @@ class GamesController < ApplicationController
       redirect_to root_path, alert: "This game has already been forfeited." and return
     end
     
-    @game.update_attribute(:forfeiting_player_id, current_user.id)
+    @game.update_attributes(forfeiting_player_id: current_user.id, game_ended: true)
     current_user.increment_loss_count
 
     other_player = User.find_by(id: @game.black_player_id == current_user.id ? @game.white_player_id : @game.black_player_id)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -88,12 +88,12 @@ class GamesController < ApplicationController
   end
 
   def forfeit
+    @game = Game.find(params[:id])
+
     if(current_user.id != @game.black_player_id && current_user.id != @game.white_player_id)
       redirect_to root_path, alert: "You are not a member of this game." and return
     end
     
-    @game = Game.find(params[:id])
-
     if !@game.forfeiting_player_id.nil?
       redirect_to root_path, alert: "This game has already been forfeited." and return
     end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -98,7 +98,7 @@ class GamesController < ApplicationController
       redirect_to root_path, alert: "This game has already been forfeited." and return
     end
     
-    @game.update_attributes(forfeiting_player_id: current_user.id, game_ended: true)
+    @game.update_attributes(forfeiting_player_id: current_user.id, ended: true)
     current_user.increment_loss_count
 
     other_player = User.find_by(id: @game.black_player_id == current_user.id ? @game.white_player_id : @game.black_player_id)
@@ -107,6 +107,19 @@ class GamesController < ApplicationController
     # Note: other player needs to be redirected (via Firebase)
 
     redirect_to root_path, notice: "You have forfeited the game. Please play again soon."
+  end
+
+  def stalemate
+    @game = Game.find(params[:id])
+
+    if @game.in_stalemate_state?
+      redirect_to game_path(@game.id) and return
+    end
+
+    @game.update_attributes(tied: true, ended: true)
+    redirect_to game_path(@game.id), notice: "The game has ended in a stalemate."
+
+    # Note: other player needs to be redirected (via Firebase)
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -15,6 +15,7 @@ class GamesController < ApplicationController
 
   def create
     @game = Game.create(game_params)
+    @game.transmit_game_ended_status_to_firebase(false)
     @game.transmit_player_on_move_to_firebase(-1)
     redirect_to game_path(@game)
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -99,10 +99,10 @@ class GamesController < ApplicationController
       redirect_to root_path, alert: ViewBro.msg_for_already_forfeited and return
     end
     
-    @game.update_attributes(forfeiting_player_id: current_user.id, ended: true)
-    current_user.increment_loss_count
-
     other_player = User.find_by(id: @game.black_player_id == current_user.id ? @game.white_player_id : @game.black_player_id)
+
+    @game.update_attributes(forfeiting_player_id: current_user.id, victorious_player_id: other_player.id, ended: true)
+    current_user.increment_loss_count
     other_player.increment_win_count if other_player
 
     @game.transmit_game_ended_status_to_firebase(true)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -105,8 +105,8 @@ class GamesController < ApplicationController
     other_player = User.find_by(id: @game.black_player_id == current_user.id ? @game.white_player_id : @game.black_player_id)
     other_player.increment_win_count if other_player
 
-    signal_end_of_game(game.id)
-    redirect_to root_path, notice: ViewBro.msg_for_forfeited_game # this needs to be moved
+    @game.transmit_game_ended_status_to_firebase(true)
+    # redirect_to root_path, notice: ViewBro.msg_for_forfeited_game
   end
 
   def stalemate
@@ -120,8 +120,8 @@ class GamesController < ApplicationController
     User.find(@game.black_player_id).increment_tie_count
     User.find(@game.white_player_id).increment_tie_count
 
-    signal_end_of_game(game.id)
-    redirect_to game_path(@game.id), notice: msg_for_stalemate # this needs to be moved
+    @game.transmit_game_ended_status_to_firebase(true)
+    # redirect_to game_path(@game.id), notice: msg_for_stalemate
   end
 
   private
@@ -129,10 +129,4 @@ class GamesController < ApplicationController
   def game_params
     params.require(:game).permit(:name, :black_player_id, :white_player_id)
   end
-
-  def signal_end_of_game(id_of_game)
-    @game = Game.find(id_of_game)
-
-  end
-
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -105,7 +105,7 @@ class GamesController < ApplicationController
     other_player = User.find_by(id: @game.black_player_id == current_user.id ? @game.white_player_id : @game.black_player_id)
     other_player.increment_win_count if other_player
 
-    @game.signal_end_of_game
+    signal_end_of_game(game.id)
     redirect_to root_path, notice: ViewBro.msg_for_forfeited_game # this needs to be moved
   end
 
@@ -119,15 +119,20 @@ class GamesController < ApplicationController
     @game.update_attributes(tied: true, ended: true)
     User.find(@game.black_player_id).increment_tie_count
     User.find(@game.white_player_id).increment_tie_count
-    signal_end_of_game
 
-    redirect_to game_path(@game.id), notice: "The game has ended in a stalemate." # this needs to be moved and refactored
+    signal_end_of_game(game.id)
+    redirect_to game_path(@game.id), notice: msg_for_stalemate # this needs to be moved
   end
 
   private
 
   def game_params
     params.require(:game).permit(:name, :black_player_id, :white_player_id)
+  end
+
+  def signal_end_of_game(id_of_game)
+    @game = Game.find(id_of_game)
+
   end
 
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -182,11 +182,18 @@ class Game < ApplicationRecord
     transmit_player_on_move_to_firebase(new_player_on_move_color)
   end
 
+  def transmit_game_ended_status_to_firebase(game_ended_boolean_state)
+    base_uri = 'https://bro-chess-b8ed8.firebaseio.com/'
+    firebase = Firebase::Client.new(base_uri)
+
+    firebase.update("game #{id}", :game_ended_boolean => game_ended_boolean_state)
+  end
+
   def transmit_player_on_move_to_firebase(new_player_on_move_color)
     base_uri = 'https://bro-chess-b8ed8.firebaseio.com/'
     firebase = Firebase::Client.new(base_uri)
 
-    firebase.set("game #{id}", :player_on_move_color => new_player_on_move_color)
+    firebase.update("game #{id}", :player_on_move_color => new_player_on_move_color)
   end
 
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -182,10 +182,6 @@ class Game < ApplicationRecord
     transmit_player_on_move_to_firebase(new_player_on_move_color)
   end
 
-  def signal_end_of_game
-    
-  end
-
   def transmit_game_ended_status_to_firebase(game_ended_boolean_state)
     base_uri = 'https://bro-chess-b8ed8.firebaseio.com/'
     firebase = Firebase::Client.new(base_uri)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -182,6 +182,10 @@ class Game < ApplicationRecord
     transmit_player_on_move_to_firebase(new_player_on_move_color)
   end
 
+  def signal_end_of_game
+    
+  end
+
   def transmit_game_ended_status_to_firebase(game_ended_boolean_state)
     base_uri = 'https://bro-chess-b8ed8.firebaseio.com/'
     firebase = Firebase::Client.new(base_uri)

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -158,14 +158,15 @@
 
 <% turn_display_class = 'turn-display '%>
 
-<% if !is_missing_player && current_user == @game.player_on_move %>
-	<% turn_display_class += 'your-turn' %>
-	<% turn_display_text = 'Your move' %>
-<% else %>
-	<% turn_display_class += 'their-turn' %>
+<% turn_display_class += (!is_missing_player && current_user == @game.player_on_move && !@game.ended) ? 'your-turn' : 'their-turn' %>
 
-	<% if is_missing_player%>
-		<% turn_display_text = 'Waiting on a bro' %>
+<% if is_missing_player%>
+	<% turn_display_text = 'Waiting on a bro' %>
+<% else %>
+	<% if @game.ended %>
+		<% turn_display_text = 'VICTORY' if current_user.id == @game.victorious_player_id %>
+		<% turn_display_text = 'DEFEAT' if !@game.tied && current_user.id != @game.victorious_player_id %>
+		<% turn_display_text = 'DRAW' if @game.tied %>
 	<% else %>
 		<% turn_display_text = (@game.player_on_move_color == 0 ? "Black": "White") + " player's move" %>
 	<% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -4,6 +4,7 @@
 	<%= controller.redirect_to root_path, alert: ViewBro.msg_for_already_forfeited %>
 <% end %>
 
+<% is_missing_player = (@game.black_player_id.nil? || @game.white_player_id.nil?) %>
 
 <div class="chess-board-render">
 	<% tile_color = 1 %>
@@ -33,16 +34,21 @@
 	<% end %>
 </div>
 
-<% turn_status = current_user == @game.player_on_move ? "on-move" : "waiting" %>
+<% if is_missing_player %>
+	<% turn_status = 'awaiting-player-join' %>
+<% else %>
+	<% turn_status = current_user == @game.player_on_move ? "on-move" : "waiting" %>
+<% end %>
+
 <div id="turn-status-indicator" class="<%=turn_status%>"></div>
 
 <script src="https://www.gstatic.com/firebasejs/7.10.0/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/7.10.0/firebase-database.js"></script>
 
-<% if !@game.ended%>
 <script>
 	$(document).ready(function(){
 
+	<% if !@game.ended && !is_missing_player %>
 		$(".drag-a-piece").draggable({ //piece image is draggable, see line 16
 			scroll: false,
 			containment: $('.chess-board-render')
@@ -88,6 +94,8 @@
 			}
 		});
 
+		<% end %>
+
 		$(function(){
 
 			var firebaseConfig = {
@@ -110,11 +118,13 @@
 				if($('#turn-status-indicator').hasClass('moved-piece')) {
 					location.reload();
 				}
+				if($('#turn-status-indicator').hasClass('awaiting-player-join')) {
+					location.reload();
+				}
 			});
 		});
 	});
 </script>
-<% end %>
 
 <script>
 	function castling(data){
@@ -136,14 +146,19 @@
 	}
 </script>
 
-
 <% turn_display_class = 'turn-display '%>
-<% if current_user == @game.player_on_move %>
-    <% turn_display_class += 'your-turn' %>
+
+<% if !is_missing_player && current_user == @game.player_on_move %>
+	<% turn_display_class += 'your-turn' %>
 	<% turn_display_text = 'Your move' %>
 <% else %>
-    <% turn_display_class += 'their-turn' %>
-	<% turn_display_text = (@game.player_on_move_color == 0 ? "Black": "White") + " player's move" %>
+	<% turn_display_class += 'their-turn' %>
+
+	<% if is_missing_player%>
+		<% turn_display_text = 'Waiting on a bro' %>
+	<% else %>
+		<% turn_display_text = (@game.player_on_move_color == 0 ? "Black": "White") + " player's move" %>
+	<% end %>
 <% end %>
 
 <div class="<%=turn_display_class%>">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -88,6 +88,15 @@
 					window.setTimeout(function(){
 						if(!unloading) {
 							location.reload();
+							/* Because of the approach the Firebase callbacks necessitated, only successful moves 
+								(ones that update piece position in our Rails database) will refresh the page. */
+
+							 /* The solution: 
+								 - Call a function to refresh the page, but only after waiting a short amount of time
+								 - The refresh function will only reload the page if the "unload" flag is set to false
+								 - If there is a successful move, the page will automatically be redirected, which will
+								 	set the "unload" flag to true
+							 */
 						}
 					}, 500); // Note the delay time of 500ms
 				});

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,9 +1,5 @@
 <% load 'lib/assets/view_bro.rb' %>
 
-<% if !@game.forfeiting_player_id.nil? %>
-	<%= controller.redirect_to root_path, alert: ViewBro.msg_for_already_forfeited %>
-<% end %>
-
 <% is_missing_player = (@game.black_player_id.nil? || @game.white_player_id.nil?) %>
 
 <div class="chess-board-render">
@@ -120,7 +116,11 @@
 
 			var database_path = `game <%= @game.id%>`
 			firebase.database().ref(database_path).on('child_changed', function(dataSnapshot){
-									
+
+				if(dataSnapshot.val() === true) {
+					location.reload(); // Reloads the game page, which will tell you how the game ended
+				}
+
 				if($('#turn-status-indicator').hasClass('waiting')) {
 					location.reload();
 				}
@@ -130,6 +130,7 @@
 				if($('#turn-status-indicator').hasClass('awaiting-player-join')) {
 					location.reload();
 				}
+
 			});
 		});
 	});

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -64,6 +64,7 @@
 <script src="https://www.gstatic.com/firebasejs/7.10.0/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/7.10.0/firebase-database.js"></script>
 
+<% if !@game.ended%>
 <script>
 	$(document).ready(function(){
 
@@ -135,6 +136,7 @@
 		});
 	});
 </script>
+<% end %>
 
 <script>
 	function castling(data){

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,13 +39,10 @@
         </ul>
         <ul class="navbar-nav ml-auto">
           <% if user_signed_in? && controller_name == 'games'%>
-
-            
-
             <li class="nav-item">
-              <% if @game.forfeiting_player_id.nil? %>
-                <%= link_to 'Forfeit Game', forfeit_path(@game), method: :post, class: "btn btn-danger", data: { confirm: "Do you really want to forfeit the game?"} %>
-              <% end %>
+             <% if @game.forfeiting_player_id.nil? && !@game.black_player_id.nil? && !@game.white_player_id.nil?%>
+                <%= link_to 'Forfeit Game', forfeit_path(@game.id), method: :post, class: "btn btn-danger", data: { confirm: "Do you really want to forfeit the game?"} %>
+             <% end %>
             </li>
           <% end %>
         </ul>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -15,7 +15,6 @@
               <b>white</b>
               to join...
               <%= link_to 'Join this game', join_as_white_game_path(game), method: :put %></li>
-
           <% end %>
         <% end %>
       </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,25 +1,48 @@
 <div class="booyah-box col-10 offset-1 col-md-4 offset-md-4">
   <h1><%= @user.email %></h1>
   <h3>Member Since: <%= @user.created_at.strftime("%B %d, %Y") %></h3>
-  <h4><%=@user.games_won %> Wins</h4>
-  <h4><%=@user.games_lost %> Losses</h4>
-  <h4><%=@user.games_drawn %> Draws</h4>
+  <div class="win-loss-draw-stats">
+    <div><%=@user.games_won %> Wins</div>
+    <div><%=@user.games_drawn %> Draws</div>
+    <div><%=@user.games_lost %> Losses</div>
+  </div>
 </div>
 
-<div class="booyah-box col-10 offset-1 col-md-4 offset-md-4">
+<div class="booyah-box col-10 offset-1 col-md-6 offset-md-3">
   <h1>Game History</h1>
   <br/>
 
   <div class="game-history-entry entry-header">
+    <div>Game ID</div>
+    <div>Created On</div>
+    <div>Opponent</div>
+    <div>Status</div>
   </div>
 
   <% Game.order(:id).each do |game| %>
     <% if (game.black_player_id == @user.id) || (game.white_player_id == @user.id) %>
       <div class="game-history-entry">
-        Game ID: <%= game.id  %>  -  
-        <%= game.created_at.strftime("%B %d, %Y") %>
+        <div><%= game.id %></div> 
+        <div><%= game.created_at.strftime("%B %d, %Y") %></div>
+        <div>
+          <% other_player_id = @user.id == game.black_player_id ? game.white_player_id : game.black_player_id %>
+          <%= User.find(other_player_id).email if other_player_id != nil %>
+        </div>
+        <div>
+          <% if game.ended %>
+            <% if game.tied %>
+              <% status = 'Tied' %>
+            <% elsif game.victorious_player_id == @user.id %>
+              <% status = 'Won' %>
+            <% elsif !game.victorious_player_id.nil? && game.victorious_player_id != @user.id %>
+              <% status = 'Lost' %>
+            <% end %>
+          <% else %>
+            <% status = other_player_id.nil? ? 'Open' : 'In Progress' %>
+          <% end %>
+          <%= status %>
+        </div>
       </div>
-
       <hr/>
     <% end %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,20 +1,26 @@
-<div>
-
+<div class="booyah-box col-10 offset-1 col-md-4 offset-md-4">
   <h1><%= @user.email %></h1>
   <h3>Member Since: <%= @user.created_at.strftime("%B %d, %Y") %></h3>
-
-
+  <h4><%=@user.games_won %> Wins</h4>
+  <h4><%=@user.games_lost %> Losses</h4>
+  <h4><%=@user.games_drawn %> Draws</h4>
+</div>
 
 <div class="booyah-box col-10 offset-1 col-md-4 offset-md-4">
-    <h1>Game History</h1>
+  <h1>Game History</h1>
+  <br/>
 
-    <% @game.each do |game| %>
-      <% if (game.black_player_id == @user.id) || (game.white_player_id == @user.id) %>
+  <div class="game-history-entry entry-header">
+  </div>
+
+  <% Game.order(:id).each do |game| %>
+    <% if (game.black_player_id == @user.id) || (game.white_player_id == @user.id) %>
+      <div class="game-history-entry">
         Game ID: <%= game.id  %>  -  
         <%= game.created_at.strftime("%B %d, %Y") %>
-        <br />
-        <br />
-      <% end %>
+      </div>
+
+      <hr/>
     <% end %>
-  </div>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   post 'games/:id/:piece_id/:x_pos/:y_pos', :to => 'games#move', :as => 'move'
   post 'game/:id/forfeit', :to => 'games#forfeit', :as => 'forfeit'
+  post 'game/:id/stalemate', :to => 'games#stalemate', :as => 'stalemate'
 
   root 'static_pages#index'
   resources :games, only: %i[new index create show update] do

--- a/db/migrate/20200318064929_add_game_status_variables_to_games.rb
+++ b/db/migrate/20200318064929_add_game_status_variables_to_games.rb
@@ -1,0 +1,7 @@
+class AddGameStatusVariablesToGames < ActiveRecord::Migration[5.2]
+  def change
+    add_column :games, :game_ended, :boolean, default: false
+    add_column :games, :game_tied, :boolean, default: false
+    add_column :games, :victorious_player_id, :int
+  end
+end

--- a/db/migrate/20200318064929_add_game_status_variables_to_games.rb
+++ b/db/migrate/20200318064929_add_game_status_variables_to_games.rb
@@ -1,7 +1,7 @@
 class AddGameStatusVariablesToGames < ActiveRecord::Migration[5.2]
   def change
-    add_column :games, :game_ended, :boolean, default: false
-    add_column :games, :game_tied, :boolean, default: false
+    add_column :games, :ended, :boolean, default: false
+    add_column :games, :tied, :boolean, default: false
     add_column :games, :victorious_player_id, :int
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_14_034333) do
+ActiveRecord::Schema.define(version: 2020_03_18_064929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,9 @@ ActiveRecord::Schema.define(version: 2020_03_14_034333) do
     t.integer "last_moved_piece_id"
     t.integer "last_moved_prev_x_pos"
     t.integer "last_moved_prev_y_pos"
+    t.boolean "game_ended", default: false
+    t.boolean "game_tied", default: false
+    t.integer "victorious_player_id"
   end
 
   create_table "pieces", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,8 +26,8 @@ ActiveRecord::Schema.define(version: 2020_03_18_064929) do
     t.integer "last_moved_piece_id"
     t.integer "last_moved_prev_x_pos"
     t.integer "last_moved_prev_y_pos"
-    t.boolean "game_ended", default: false
-    t.boolean "game_tied", default: false
+    t.boolean "ended", default: false
+    t.boolean "tied", default: false
     t.integer "victorious_player_id"
   end
 

--- a/lib/assets/view_bro.rb
+++ b/lib/assets/view_bro.rb
@@ -24,6 +24,10 @@ class ViewBro
 		return 'You need to sign in or sign up before continuing.'
 	end
 
+	def self.msg_for_stalemate
+		return 'The game has ended in a stalemate.'
+	end
+
 	def self.svg_scale 
 		return 45
 	end


### PR DESCRIPTION
Adds win/loss type stats to `user` and win/loss type variables to `game`.

Updates forfeit and stalemate logic to utilize aforementioned `game` variables. Routing and Firebase callbacks also implemented to work with these.

Updates 'turn-display' to include message for waiting for another player to join. When game is over, it now displays win/loss/draw status.

Disables drag-and-drop if the game is over or if the game only has one player.


Fixes #65 
Fixes #87 
Fixes #88 
Fixes #101 
